### PR TITLE
Remove workaround due to limited space

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,10 +48,7 @@ jobs:
       shell: bash
       run: |
         # TinyXML is not installed as a workaround for https://github.com/robotology/ycm/pull/296
-        C:/robotology/vcpkg/vcpkg.exe --overlay-ports=C:/robotology-vcpkg-binary-ports install --triplet x64-windows ace freeglut gsl eigen3 ode openssl libxml2 eigen3 opencv3 matio sdl1 sdl2 qt5-base  ipopt-binary 
-        # Remove temporary files https://github.com/Microsoft/vcpkg/blob/master/docs/about/faq.md#how-can-i-remove-temporary-files
-        rm -rf C:/robotology/vcpkg/buildtrees 
-        C:/robotology/vcpkg/vcpkg.exe --overlay-ports=C:/robotology-vcpkg-binary-ports install --triplet x64-windows qt5-declarative qt5-multimedia qt5-quickcontrols2
+        C:/robotology/vcpkg/vcpkg.exe --overlay-ports=C:/robotology-vcpkg-binary-ports install --triplet x64-windows ace freeglut gsl eigen3 ode openssl libxml2 eigen3 opencv3 matio sdl1 sdl2 qt5-base ipopt-binary qt5-declarative qt5-multimedia qt5-quickcontrols2
         # Remove temporary files https://github.com/Microsoft/vcpkg/blob/master/docs/about/faq.md#how-can-i-remove-temporary-files
         rm -rf C:/robotology/vcpkg/buildtrees 
         rm -rf C:/robotology/vcpkg/packages 


### PR DESCRIPTION
Apparently now on  GitHub Actions you have ~131 GB on `C:/`, so  it should be possible to remove some workarounds that were inserted related to that. 

Ref: https://github.com/actions/virtual-environments/issues/326